### PR TITLE
fix: Typo, subgroups of H not G

### DIFF
--- a/16D50-ExampleOfInjectiveModule.tex
+++ b/16D50-ExampleOfInjectiveModule.tex
@@ -44,7 +44,7 @@ In the category of unitary $\mathbb{Z}$-modules (which is the category of Abelia
 \begin{proof}
 We have to show that, if $G$ is a divisible Group, $\varphi: U \to G$ is any homomorphism, and $U$ is a subgroup of a Group $H$, there is a homomorphism $\psi: H \to G$ such that the restriction $\psi|_U = \varphi$. In other words, we want to extend $\varphi$ to a homomorphism $H \to G$.
 
-Let $\mathcal{D}$ be the set of pairs $(K, \psi)$ such that $K$ is a subgroup of $G$ containing $U$ and $\psi: K \to G$ is a homomorphism with $\psi|_U = \varphi$. Then $\mathcal{D}$ ist non-empty since it contains $(U, \varphi)$, and it is partially ordered by
+Let $\mathcal{D}$ be the set of pairs $(K, \psi)$ such that $K$ is a subgroup of $H$ containing $U$ and $\psi: K \to G$ is a homomorphism with $\psi|_U = \varphi$. Then $\mathcal{D}$ ist non-empty since it contains $(U, \varphi)$, and it is partially ordered by
 \[ (K, \psi) \leq (K', \psi') :\Longleftrightarrow K \subseteq K' \text{ and } \psi'|_K = \psi. \]
 
 For any ascending chain


### PR DESCRIPTION
fix: Typo, subgroups of H not G